### PR TITLE
changed socket design to address multiple repeat errors

### DIFF
--- a/angular/package-lock.json
+++ b/angular/package-lock.json
@@ -5134,6 +5134,11 @@
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
       "dev": true
     },
+    "ng-textarea-enter": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/ng-textarea-enter/-/ng-textarea-enter-0.2.2.tgz",
+      "integrity": "sha512-8Hu7F1aR1WEHTje+9JDmim4QQyNCQHo8B9wVuOMKKJBcH8p8Yj/+pe6J9tOXy3X5KxR4U7ec52+SOdANvB7DKg=="
+    },
     "no-case": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",

--- a/angular/package.json
+++ b/angular/package.json
@@ -22,6 +22,7 @@
     "@angular/platform-browser-dynamic": "^5.0.0",
     "@angular/router": "^5.0.0",
     "core-js": "^2.4.1",
+    "ng-textarea-enter": "^0.2.2",
     "rxjs": "^5.5.2",
     "zone.js": "^0.8.14"
   },

--- a/angular/src/app/home/messageboard/messageboard.component.ts
+++ b/angular/src/app/home/messageboard/messageboard.component.ts
@@ -3,7 +3,6 @@ import { Message } from '../../models';
 import { MessageService } from '../../services/message.service';
 import { ChannelService } from '../../services/channel.service';
 import { Router } from '@angular/router';
-import * as io from 'socket.io-client';
 
 @Component({
   selector: 'app-messageboard',
@@ -13,14 +12,13 @@ import * as io from 'socket.io-client';
 export class MessageboardComponent implements OnInit {
   // @Input() channelId: String;
   @ViewChild('all_messages') el_messages: ElementRef;
+  messages: Array<Message> = [];
   channelId: String = "";
-  socket = io("http://localhost:8000");
+  connection;
 
   // developmental variables
   // teamId: String = "5a398ac2e97b1f1a38d165da";
   // channelId: String = "5a398ac2e97b1f1a38d165db";
-
-  messages: Array<Message> = [];
 
   constructor(
     private _msgService: MessageService,
@@ -29,48 +27,28 @@ export class MessageboardComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    // subscribe to the current channel
-    this._msgService.getChannelMsgs(this.channelId);
+    // subscribe to the current channel observable
+    // and get channel's messages
     this._channelService.channelCurrentObserver.subscribe(
       (currChannel) => {
         this.channelId = currChannel._id;
         this._msgService.getChannelMsgs(this.channelId);
       });
-    // subscribe to the messages observable (dependent on channel observer)
+
+    // subscribe to the messages observable
     this._msgService.messagesObserver.subscribe(
       (msgData) => {
         this.messages = msgData;
-        // console.log(this.messages);
-        // if (this.messages.length > 0) {
-        //   window.setInterval(function() {
-        //     var elem = document.querySelector(".msgsContainer");
-        //     elem.scrollTop = elem.scrollHeight;
-        //   }, 1000);
-        // }
     });
 
-    // listen through a socket for new messages
-    this.socket.on("new_message", function (data) {
-      console.log("Received emit from the server for a new message!");
-      if (data.message._channel === this.channelId) {
-        // this.messages.push(data.message);
-        this._msgService.getChannelMsgs(this.channelId);
-        this.scrollToBottom();
-      }
-    }.bind(this));
+    // subscribe to the socket connection to receive new messages from server broadcast
+    this._msgService.msgSocketObserver().subscribe();
   }
+
   ngAfterViewChecked() {
     // console.log("VIEW UPDATED!");
     this.scrollToBottom();
   }
-
-  // only need ngOnChanges if channelId is an Input
-  // removed when it was made an observable service
-  // ngOnChanges(changes) {
-  //   if (changes.channelId) {
-  //     this._msgService.getChannelMsgs(this.channelId);
-  //   }
-  // }
 
   scrollToBottom(): void {
     try {

--- a/angular/src/app/home/new-message/new-message.component.css
+++ b/angular/src/app/home/new-message/new-message.component.css
@@ -4,8 +4,9 @@ form {
 input {
     display: inline-block;
 }
-textarea {
+#message_input {
     flex: 1;
+    min-height: 3.75em;
 }
 .input-group {
     flex: 1;

--- a/angular/src/app/home/new-message/new-message.component.html
+++ b/angular/src/app/home/new-message/new-message.component.html
@@ -2,6 +2,8 @@
   <div class="input-group">
     <div class="input-group-addon">+</div>
     <textarea type="text" class="form-control" placeholder="Message"
+      ng-textarea-enter="textareaAction()"
+      id="message_input"
       tabindex="1"
       name="content"
       minlength="2"
@@ -22,3 +24,7 @@
     <small class="col-md-12" *ngIf="content.errors?.maxlength && content.touched">Content may have no more than 500 characters.</small>
   </div>
 </form>
+
+<script>
+
+</script>

--- a/angular/src/app/home/new-message/new-message.component.ts
+++ b/angular/src/app/home/new-message/new-message.component.ts
@@ -1,9 +1,10 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit, AfterViewInit, Input } from '@angular/core';
 import { Message } from '../../models';
 import { MessageService } from '../../services/message.service';
 import { ChannelService } from '../../services/channel.service';
 import { Router } from '@angular/router';
-import * as io from 'socket.io-client';
+import * as enter from 'ng-textarea-enter';
+import { window } from 'Rxjs/operator/window';
 
 @Component({
   selector: 'app-new-message',
@@ -13,7 +14,6 @@ import * as io from 'socket.io-client';
 export class NewMessageComponent implements OnInit {
   channelId: String = "";
   msg: Message = new Message();
-  socket = io("http://localhost:8000");
 
   // developmental variables
   // teamId: String = "5a398ac2e97b1f1a38d165da";
@@ -33,15 +33,32 @@ export class NewMessageComponent implements OnInit {
       });
   }
 
+  ngAfterViewInit() {
+    document.getElementById("#message_input").addEventListener("keydown", function() {
+      console.log("KEY WAS PRESSED");
+
+    })
+  }
+
   onSubmit() {
     this.msg._channel = this.channelId;
     console.log("Submitting message:");
     console.log(this.msg);
     this._msgService.createMsg(this.msg).then(
       (result) => {
-        this.socket.emit('create_message', result);
+        this._msgService.emitNewMessage(result);
     }, (err) => console.log(err) );
     this.msg = new Message();
   }
 
+  textareaAction() {
+    console.log("In TextareaAction ******")
+  //   // document.getElementById("#message_input").onkeyp
+  //   // keypress(function (key) {
+  //   //   if (key.which == 13) {
+  //   //     // if key press is enter, submit the message
+  //   //     console.log("ENTER Key Pressed");
+  //   //   }
+  //   // })
+  }
 }

--- a/angular/src/app/services/message.service.ts
+++ b/angular/src/app/services/message.service.ts
@@ -1,18 +1,60 @@
 import { Injectable } from '@angular/core';
 import { Http } from '@angular/http';
 import { BehaviorSubject } from 'Rxjs';
+import { Subject } from 'rxjs/Subject';
+import { Observable } from 'rxjs/Observable';
+import * as io from 'socket.io-client';
 import { Message } from '../models';
+import { ChannelService } from './channel.service';
 
 let _dbUrl: String = "/api/message/";
 
 @Injectable()
 export class MessageService {
+  socket = io("http://localhost:4000");
+  channelId: String = "";
   messagesObserver: BehaviorSubject<any[]> = new BehaviorSubject([]);
 
-  constructor(private _http: Http) { }
+  constructor(
+    private _http: Http,
+    private _channelService: ChannelService
+  ) {
+    // subscribe to the channel service to maintain the current channel
+    this._channelService.channelCurrentObserver.subscribe(
+      (currChannel) => {
+        this.channelId = currChannel._id;
+    });
+  }
 
   updateMsgsObserver(newData: any): void {
     this.messagesObserver.next(newData);
+  }
+
+  // Socket Message Listener Functions
+  msgSocketObserver() {
+    let observable = new Observable(observer => {
+      this.socket.on("new_message", (data) => {
+        console.log("Received Emit new message from the server");
+        console.log("Msg Received:", data);
+        // check if the new message belongs to the user's channel
+        if (data.message._channel == this.channelId) {
+          // push message to an array of messages
+          let messages = this.messagesObserver.getValue();
+          messages.push(data.message);
+          this.updateMsgsObserver(messages);
+        }
+      });
+      return () => {
+        this.socket.disconnect();
+      };
+    });
+    return observable;
+  }
+
+  // Socket Message Emit Functions
+  emitNewMessage(msg) {
+    this.socket.emit("create_message", msg);
+    console.log("Emitted Message:", msg);
   }
 
   createMsg(msg: Message) {
@@ -23,7 +65,6 @@ export class MessageService {
         .map(response => response.json())
         .subscribe(response => {
           console.log("Completed message create and received response");
-          console.log("Message returned from submit: ");
           console.log(response);
           this.getChannelMsgs(msg._channel);
           resolve(response);
@@ -49,7 +90,6 @@ export class MessageService {
   }
 
   getChannelMsgs(channelId: String) {
-    console.log(_dbUrl + "search/ch/" + channelId)
     this._http.get(_dbUrl + "search/ch/" + channelId)
       .subscribe(
       response => {
@@ -60,5 +100,6 @@ export class MessageService {
         console.log(error);
       });
   }
+
 
 }

--- a/angular/src/index.html
+++ b/angular/src/index.html
@@ -24,6 +24,9 @@
         $(this).css("background-color", "lightgray")
       });
     });
+
   </script>
 </body>
 </html>
+
+


### PR DESCRIPTION
changed socket design - moved socket to the message service -- and adapted client listener to push instead of get all messages again through a repeated api call --- should address issue of multiple messages appearing on broadcast ... and allow for administrative messages to push to the channel view